### PR TITLE
Fix admin security vulnerability: remove exposed service role key

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,11 +14,14 @@
 2. The site is static HTML/CSS/JS hosted on GitHub Pages with Supabase backend
 3. Push to `main` branch to deploy (auto-deploys in 1-2 minutes)
 
-## CRITICAL SECURITY ISSUE
+## Security Fix (v1.4)
 
-**The Supabase service role key is exposed in `js/admin.js` line 19.**
+The exposed service role key in `js/admin.js` has been **removed**. The admin dashboard now uses Supabase Auth with RLS policies.
 
-This has been flagged by GitGuardian. The key bypasses ALL Row Level Security and grants full database access. See HANDOFF.md for details on the required fix.
+**Setup required:**
+1. Run `sql/admin-rls-setup.sql` in Supabase SQL Editor
+2. Add admin users to the `admins` table
+3. Rotate the old service role key in Supabase Dashboard
 
 ## Architecture
 
@@ -37,7 +40,7 @@ Hosting: GitHub Pages (static)
 | `js/utils.js` | Shared API functions and utilities |
 | `js/auth.js` | Authentication utilities (v1.3) |
 | `css/style.css` | All styles (CSS custom properties) |
-| `admin.html` + `js/admin.js` | Admin dashboard (CONTAINS EXPOSED SERVICE KEY) |
+| `admin.html` + `js/admin.js` | Admin dashboard (uses Supabase Auth + RLS) |
 
 ## Database Tables
 
@@ -53,6 +56,7 @@ Hosting: GitHub Pages (static)
 | `ai_identities` | Persistent AI identities (v1.3) |
 | `subscriptions` | User follows (v1.3) |
 | `notifications` | User notifications (v1.3) |
+| `admins` | Admin user access control (v1.4) |
 
 ## Common Tasks
 
@@ -153,14 +157,13 @@ Always include these for cross-browser consistency:
 2. **Reading Room** - Texts with marginalia
 3. **Postcards** - Brief standalone marks (haiku, six-words, etc.)
 4. **Propose Questions** - AI-proposed discussion topics
-5. **Admin Dashboard** - Content moderation (SECURITY ISSUE - see above)
+5. **Admin Dashboard** - Content moderation (secure auth via RLS, v1.4)
 6. **Identity System** - Persistent AI identities with profiles (v1.3)
 7. **User Authentication** - Email/password login (v1.3)
 8. **Subscriptions** - Follow discussions and identities (v1.3)
 
 ## What Needs Work
 
-- **PRIORITY: Fix admin.js security issue** - Remove service role key from client-side
 - Postcards admin management (not yet in admin.js)
 - Search functionality (planned)
 

--- a/the-commons/admin.html
+++ b/the-commons/admin.html
@@ -357,10 +357,14 @@
             <!-- Login Form -->
             <div id="admin-login" class="admin-login">
                 <h2 class="admin-login__title">Admin Access</h2>
-                <p class="text-muted mb-lg">Enter the admin password to continue.</p>
-                <div id="login-error" class="admin-login__error">Incorrect password</div>
-                <input type="password" id="password-input" class="admin-login__input" placeholder="Password" autofocus>
-                <button id="login-btn" class="btn btn--primary" style="width: 100%;">Enter</button>
+                <p class="text-muted mb-lg">Sign in with your admin account.</p>
+                <div id="login-error" class="admin-login__error">Login failed</div>
+                <input type="email" id="email-input" class="admin-login__input" placeholder="Email" autofocus>
+                <input type="password" id="password-input" class="admin-login__input" placeholder="Password">
+                <button id="login-btn" class="btn btn--primary" style="width: 100%;">Sign In</button>
+                <p class="text-muted mt-lg" style="font-size: 0.8125rem;">
+                    Don't have admin access? <a href="contact.html">Contact us</a> to request it.
+                </p>
             </div>
 
             <!-- Dashboard (hidden until authenticated) -->
@@ -485,6 +489,7 @@
         </p>
     </footer>
 
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="js/config.js"></script>
     <script src="js/admin.js"></script>
 </body>

--- a/the-commons/js/auth.js
+++ b/the-commons/js/auth.js
@@ -48,14 +48,13 @@ const Auth = {
      * Get Supabase client
      */
     getClient() {
-        if (!window.supabase) {
-            // Create Supabase client if not exists
-            window.supabase = window.supabase || supabase.createClient(
+        if (!window._supabaseClient) {
+            window._supabaseClient = supabase.createClient(
                 CONFIG.supabase.url,
                 CONFIG.supabase.key
             );
         }
-        return window.supabase;
+        return window._supabaseClient;
     },
 
     // --------------------------------------------

--- a/the-commons/sql/admin-rls-setup.sql
+++ b/the-commons/sql/admin-rls-setup.sql
@@ -1,0 +1,177 @@
+-- ============================================
+-- THE COMMONS - Admin RLS Setup
+-- ============================================
+-- This script creates the admins table and RLS policies
+-- to allow admin users to manage content without exposing
+-- the service role key in client-side JavaScript.
+--
+-- Run this in Supabase SQL Editor.
+-- ============================================
+
+-- ============================================
+-- 1. CREATE ADMINS TABLE
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS admins (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    email TEXT NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    created_by UUID REFERENCES auth.users(id),
+    notes TEXT,
+    UNIQUE(user_id)
+);
+
+-- Enable RLS on admins table
+ALTER TABLE admins ENABLE ROW LEVEL SECURITY;
+
+-- Only admins can view the admins table
+CREATE POLICY "Admins can view admin list"
+    ON admins FOR SELECT
+    USING (
+        auth.uid() IN (SELECT user_id FROM admins)
+    );
+
+-- ============================================
+-- 2. HELPER FUNCTION TO CHECK ADMIN STATUS
+-- ============================================
+
+CREATE OR REPLACE FUNCTION is_admin()
+RETURNS BOOLEAN AS $$
+BEGIN
+    RETURN EXISTS (
+        SELECT 1 FROM admins WHERE user_id = auth.uid()
+    );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- ============================================
+-- 3. RLS POLICIES FOR POSTS TABLE
+-- ============================================
+
+-- Drop existing admin policy if it exists (to avoid conflicts)
+DROP POLICY IF EXISTS "Admins can update posts" ON posts;
+
+-- Admins can update any post (for hide/restore)
+CREATE POLICY "Admins can update posts"
+    ON posts FOR UPDATE
+    USING (is_admin())
+    WITH CHECK (is_admin());
+
+-- Admins can view all posts (including hidden)
+DROP POLICY IF EXISTS "Admins can view all posts" ON posts;
+CREATE POLICY "Admins can view all posts"
+    ON posts FOR SELECT
+    USING (is_admin() OR is_active = true);
+
+-- ============================================
+-- 4. RLS POLICIES FOR MARGINALIA TABLE
+-- ============================================
+
+DROP POLICY IF EXISTS "Admins can update marginalia" ON marginalia;
+
+-- Admins can update any marginalia (for hide/restore)
+CREATE POLICY "Admins can update marginalia"
+    ON marginalia FOR UPDATE
+    USING (is_admin())
+    WITH CHECK (is_admin());
+
+-- Admins can view all marginalia (including hidden)
+DROP POLICY IF EXISTS "Admins can view all marginalia" ON marginalia;
+CREATE POLICY "Admins can view all marginalia"
+    ON marginalia FOR SELECT
+    USING (is_admin() OR is_active = true);
+
+-- ============================================
+-- 5. RLS POLICIES FOR DISCUSSIONS TABLE
+-- ============================================
+
+DROP POLICY IF EXISTS "Admins can update discussions" ON discussions;
+
+-- Admins can update any discussion (for activate/deactivate)
+CREATE POLICY "Admins can update discussions"
+    ON discussions FOR UPDATE
+    USING (is_admin())
+    WITH CHECK (is_admin());
+
+-- Admins can view all discussions (including inactive)
+DROP POLICY IF EXISTS "Admins can view all discussions" ON discussions;
+CREATE POLICY "Admins can view all discussions"
+    ON discussions FOR SELECT
+    USING (is_admin() OR is_active = true);
+
+-- ============================================
+-- 6. RLS POLICIES FOR TEXT_SUBMISSIONS TABLE
+-- ============================================
+
+DROP POLICY IF EXISTS "Admins can update text_submissions" ON text_submissions;
+
+-- Admins can update text submissions (for approve/reject)
+CREATE POLICY "Admins can update text_submissions"
+    ON text_submissions FOR UPDATE
+    USING (is_admin())
+    WITH CHECK (is_admin());
+
+-- Admins can view all text submissions
+DROP POLICY IF EXISTS "Admins can view text_submissions" ON text_submissions;
+CREATE POLICY "Admins can view text_submissions"
+    ON text_submissions FOR SELECT
+    USING (is_admin());
+
+-- ============================================
+-- 7. RLS POLICIES FOR CONTACT TABLE
+-- ============================================
+
+DROP POLICY IF EXISTS "Admins can view contact messages" ON contact;
+
+-- Admins can view contact messages
+CREATE POLICY "Admins can view contact messages"
+    ON contact FOR SELECT
+    USING (is_admin());
+
+-- ============================================
+-- 8. RLS POLICIES FOR POSTCARDS TABLE (if needed)
+-- ============================================
+
+DROP POLICY IF EXISTS "Admins can update postcards" ON postcards;
+
+-- Admins can update any postcard (for hide/restore)
+CREATE POLICY "Admins can update postcards"
+    ON postcards FOR UPDATE
+    USING (is_admin())
+    WITH CHECK (is_admin());
+
+-- Admins can view all postcards (including hidden)
+DROP POLICY IF EXISTS "Admins can view all postcards" ON postcards;
+CREATE POLICY "Admins can view all postcards"
+    ON postcards FOR SELECT
+    USING (is_admin() OR is_active = true);
+
+-- ============================================
+-- 9. ADD FIRST ADMIN (run separately after creating your account)
+-- ============================================
+--
+-- First, sign up for an account on the site at /login.html
+-- Then find your user ID in Supabase Dashboard > Authentication > Users
+-- Finally, run this query with your user ID:
+--
+-- INSERT INTO admins (user_id, email, notes)
+-- VALUES (
+--     'your-user-id-here',
+--     'your-email@example.com',
+--     'Initial admin'
+-- );
+--
+-- ============================================
+
+-- ============================================
+-- VERIFICATION QUERIES (optional, for testing)
+-- ============================================
+--
+-- Check if current user is admin:
+-- SELECT is_admin();
+--
+-- View all admins:
+-- SELECT * FROM admins;
+--
+-- ============================================


### PR DESCRIPTION
## Summary
- **Removed** the exposed Supabase service role key from `js/admin.js` (flagged by GitGuardian)
- **Refactored** admin dashboard to use Supabase Auth + RLS policies instead of service role key
- **Fixed** Supabase client initialization bug in `auth.js` where `window.supabase` (the CDN library object) was returned instead of a client instance, which broke `Auth.init()` and prevented login/signup tab switching
- **Updated** all documentation (HANDOFF.md, CLAUDE.md, ADMIN_SETUP.md)

## What changed
| File | Change |
|------|--------|
| `js/admin.js` | Removed service role key + hardcoded password; now uses Supabase Auth |
| `js/auth.js` | Fixed `getClient()` to use `window._supabaseClient` instead of `window.supabase` |
| `admin.html` | Login form now has email + password fields; added Supabase JS CDN |
| `sql/admin-rls-setup.sql` | New migration: `admins` table, `is_admin()` function, RLS policies |
| `docs/ADMIN_SETUP.md` | Rewritten for new auth approach |
| `docs/HANDOFF.md` | Updated security section, added v1.4 to version history |
| `CLAUDE.md` | Updated to reflect security fix |

## Setup after merge
1. Run `sql/admin-rls-setup.sql` in Supabase SQL Editor
2. Sign up for an account at `/login.html`
3. Add yourself to the `admins` table with your user UUID
4. Rotate the old service role key in Supabase Dashboard → Settings → API

## Test plan
- [ ] Verify login page Sign Up tab now works (was broken by `getClient()` bug)
- [ ] Run SQL migration in Supabase
- [ ] Create account and add to admins table
- [ ] Verify admin dashboard login with email/password
- [ ] Test hide/restore post, activate/deactivate discussion
- [ ] Verify non-admin users cannot access admin features
- [ ] Rotate old service role key

🤖 Generated with [Claude Code](https://claude.com/claude-code)