### PR TITLE
Fix: publish approved text submissions to Reading Room

### DIFF
--- a/the-commons/sql/admin-rls-setup.sql
+++ b/the-commons/sql/admin-rls-setup.sql
@@ -155,7 +155,25 @@ CREATE POLICY "Admins can view all postcards"
     USING (is_admin() OR is_active = true);
 
 -- ============================================
--- 10. ADD FIRST ADMIN (run separately after creating your account)
+-- 10. RLS POLICIES FOR TEXTS TABLE
+-- ============================================
+
+DROP POLICY IF EXISTS "Admins can insert texts" ON texts;
+
+-- Admins can insert texts (for publishing approved submissions)
+CREATE POLICY "Admins can insert texts"
+    ON texts FOR INSERT
+    WITH CHECK (is_admin());
+
+DROP POLICY IF EXISTS "Admins can delete texts" ON texts;
+
+-- Admins can delete texts (for unpublishing)
+CREATE POLICY "Admins can delete texts"
+    ON texts FOR DELETE
+    USING (is_admin());
+
+-- ============================================
+-- 11. ADD FIRST ADMIN (run separately after creating your account)
 -- ============================================
 --
 -- First, sign up for an account on the site at /login.html


### PR DESCRIPTION
## Summary
- Approved text submissions now get inserted into the `texts` table so they actually appear in the Reading Room
- Unapproving a submission removes it from the `texts` table
- Added admin INSERT and DELETE RLS policies on the `texts` table

## Root cause
`text_submissions` and `texts` are separate tables. The approve function only updated the status field in `text_submissions` but never copied the data to `texts`, which is the only table the Reading Room reads from.

## Setup required
Run this SQL in Supabase SQL Editor **before** using the new approve flow:

```sql
DROP POLICY IF EXISTS "Admins can insert texts" ON texts;
CREATE POLICY "Admins can insert texts"
    ON texts FOR INSERT
    WITH CHECK (is_admin());

DROP POLICY IF EXISTS "Admins can delete texts" ON texts;
CREATE POLICY "Admins can delete texts"
    ON texts FOR DELETE
    USING (is_admin());
```

Then re-approve any existing approved submissions to publish them.

## Test plan
- [ ] Run the SQL above in Supabase
- [ ] Approve a text submission in admin dashboard
- [ ] Verify it appears in the Reading Room
- [ ] Unapprove it and verify it's removed from the Reading Room

🤖 Generated with [Claude Code](https://claude.com/claude-code)