### PR TITLE
Fix clipboard copy functionality

### DIFF
--- a/the-commons/js/discussion.js
+++ b/the-commons/js/discussion.js
@@ -229,24 +229,48 @@
     // Copy context to clipboard
     copyContextBtn.addEventListener('click', async () => {
         const contextText = contextContent.textContent;
-        
-        try {
-            await navigator.clipboard.writeText(contextText);
-            copyContextBtn.textContent = 'Copied!';
+
+        if (!contextText || contextText.trim() === '') {
+            copyContextBtn.textContent = 'Nothing to copy';
             setTimeout(() => {
                 copyContextBtn.textContent = 'Copy to Clipboard';
             }, 2000);
-        } catch (err) {
-            // Fallback for older browsers
-            const textarea = document.createElement('textarea');
-            textarea.value = contextText;
-            document.body.appendChild(textarea);
-            textarea.select();
-            document.execCommand('copy');
-            document.body.removeChild(textarea);
+            return;
+        }
+
+        copyContextBtn.disabled = true;
+        copyContextBtn.textContent = 'Copying...';
+
+        const success = await Utils.copyToClipboard(contextText);
+
+        if (success) {
             copyContextBtn.textContent = 'Copied!';
             setTimeout(() => {
                 copyContextBtn.textContent = 'Copy to Clipboard';
+                copyContextBtn.disabled = false;
+            }, 2000);
+        } else {
+            // Copy failed - show manual option
+            copyContextBtn.textContent = 'Copy failed';
+
+            const shouldPrompt = confirm('Automatic copy failed. Would you like to see the text to copy manually?');
+            if (shouldPrompt) {
+                const modal = document.createElement('div');
+                modal.style.cssText = 'position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.8);z-index:10000;display:flex;align-items:center;justify-content:center;padding:1rem;';
+                modal.innerHTML = `
+                    <div style="background:var(--bg-primary,#1a1a2e);padding:1.5rem;border-radius:8px;max-width:600px;max-height:80vh;overflow:auto;color:var(--text-primary,#fff);">
+                        <p style="margin-bottom:1rem;">Select all the text below and copy it (Ctrl+C or Cmd+C):</p>
+                        <textarea readonly style="width:100%;height:300px;background:var(--bg-deep,#0f0f1a);color:var(--text-primary,#fff);border:1px solid var(--border-color,#333);padding:0.5rem;font-family:monospace;font-size:12px;">${Utils.escapeHtml(contextText)}</textarea>
+                        <button onclick="this.parentElement.parentElement.remove()" style="margin-top:1rem;padding:0.5rem 1rem;background:var(--accent-gold,#d4a574);color:#000;border:none;border-radius:4px;cursor:pointer;">Close</button>
+                    </div>
+                `;
+                document.body.appendChild(modal);
+                modal.querySelector('textarea').select();
+            }
+
+            setTimeout(() => {
+                copyContextBtn.textContent = 'Copy to Clipboard';
+                copyContextBtn.disabled = false;
             }, 2000);
         }
     });

--- a/the-commons/js/text.js
+++ b/the-commons/js/text.js
@@ -138,23 +138,46 @@
     copyContextBtn.addEventListener('click', async () => {
         const contextText = contextContent.textContent;
 
-        try {
-            await navigator.clipboard.writeText(contextText);
-            copyContextBtn.textContent = 'Copied!';
+        if (!contextText || contextText.trim() === '') {
+            copyContextBtn.textContent = 'Nothing to copy';
             setTimeout(() => {
                 copyContextBtn.textContent = 'Copy to Clipboard';
             }, 2000);
-        } catch (err) {
-            // Fallback for older browsers
-            const textarea = document.createElement('textarea');
-            textarea.value = contextText;
-            document.body.appendChild(textarea);
-            textarea.select();
-            document.execCommand('copy');
-            document.body.removeChild(textarea);
+            return;
+        }
+
+        copyContextBtn.disabled = true;
+        copyContextBtn.textContent = 'Copying...';
+
+        const success = await Utils.copyToClipboard(contextText);
+
+        if (success) {
             copyContextBtn.textContent = 'Copied!';
             setTimeout(() => {
                 copyContextBtn.textContent = 'Copy to Clipboard';
+                copyContextBtn.disabled = false;
+            }, 2000);
+        } else {
+            copyContextBtn.textContent = 'Copy failed';
+
+            const shouldPrompt = confirm('Automatic copy failed. Would you like to see the text to copy manually?');
+            if (shouldPrompt) {
+                const modal = document.createElement('div');
+                modal.style.cssText = 'position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.8);z-index:10000;display:flex;align-items:center;justify-content:center;padding:1rem;';
+                modal.innerHTML = `
+                    <div style="background:var(--bg-primary,#1a1a2e);padding:1.5rem;border-radius:8px;max-width:600px;max-height:80vh;overflow:auto;color:var(--text-primary,#fff);">
+                        <p style="margin-bottom:1rem;">Select all the text below and copy it (Ctrl+C or Cmd+C):</p>
+                        <textarea readonly style="width:100%;height:300px;background:var(--bg-deep,#0f0f1a);color:var(--text-primary,#fff);border:1px solid var(--border-color,#333);padding:0.5rem;font-family:monospace;font-size:12px;">${Utils.escapeHtml(contextText)}</textarea>
+                        <button onclick="this.parentElement.parentElement.remove()" style="margin-top:1rem;padding:0.5rem 1rem;background:var(--accent-gold,#d4a574);color:#000;border:none;border-radius:4px;cursor:pointer;">Close</button>
+                    </div>
+                `;
+                document.body.appendChild(modal);
+                modal.querySelector('textarea').select();
+            }
+
+            setTimeout(() => {
+                copyContextBtn.textContent = 'Copy to Clipboard';
+                copyContextBtn.disabled = false;
             }, 2000);
         }
     });


### PR DESCRIPTION
## Summary
- Improved `copyToClipboard` in utils.js with better input validation and robust fallback
- All copy buttons now use `Utils.copyToClipboard` consistently
- Added manual copy modal fallback when clipboard API fails
- Affected pages: discussions.html, discussion.html, text.html (Reading Room)

Fixes reported issue where "Copy Recent Posts" button sometimes copied a link instead of text, or copied nothing to clipboard.

## Test plan
- [ ] Test "Copy Recent Posts" button on discussions.html
- [ ] Test "Copy to Clipboard" button on individual discussion pages
- [ ] Test "Copy to Clipboard" button in Reading Room text pages
- [ ] Verify manual copy modal appears when clipboard fails (can test by blocking clipboard permissions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)