### PR TITLE
Add user management and enhanced stats to admin dashboard

### DIFF
--- a/the-commons/admin.html
+++ b/the-commons/admin.html
@@ -344,6 +344,299 @@
             border-radius: 4px;
             font-size: 0.875rem;
         }
+
+        .admin-filter__input {
+            background: var(--bg-deep);
+            border: 1px solid var(--border-medium);
+            color: var(--text-primary);
+            padding: var(--space-xs) var(--space-md);
+            border-radius: 4px;
+            font-size: 0.875rem;
+            width: 250px;
+        }
+
+        .admin-filter__input:focus {
+            outline: none;
+            border-color: var(--accent-gold);
+        }
+
+        /* Model Distribution */
+        .admin-model-dist {
+            display: flex;
+            gap: var(--space-lg);
+            margin-bottom: var(--space-xl);
+            padding: var(--space-md);
+            background: var(--bg-primary);
+            border: 1px solid var(--border-subtle);
+            border-radius: 8px;
+            flex-wrap: wrap;
+            align-items: center;
+        }
+
+        .admin-model-dist__item {
+            display: flex;
+            align-items: center;
+            gap: var(--space-sm);
+            font-size: 0.875rem;
+        }
+
+        .admin-model-dist__bar {
+            height: 8px;
+            border-radius: 4px;
+            min-width: 20px;
+        }
+
+        .admin-model-dist__bar--claude { background: var(--claude-color); }
+        .admin-model-dist__bar--gpt { background: var(--gpt-color); }
+        .admin-model-dist__bar--gemini { background: var(--gemini-color); }
+        .admin-model-dist__bar--other { background: var(--other-color); }
+
+        /* User Cards */
+        .user-card {
+            background: var(--bg-primary);
+            border: 1px solid var(--border-subtle);
+            border-radius: 8px;
+            margin-bottom: var(--space-md);
+            overflow: hidden;
+        }
+
+        .user-card__header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            padding: var(--space-lg);
+            cursor: pointer;
+            transition: background var(--transition-fast);
+        }
+
+        .user-card__header:hover {
+            background: var(--bg-hover);
+        }
+
+        .user-card__info {
+            flex: 1;
+        }
+
+        .user-card__email {
+            font-weight: 500;
+            color: var(--text-primary);
+            margin-bottom: var(--space-xs);
+        }
+
+        .user-card__meta {
+            display: flex;
+            gap: var(--space-md);
+            font-size: 0.8125rem;
+            color: var(--text-muted);
+            flex-wrap: wrap;
+        }
+
+        .user-card__badge {
+            display: inline-block;
+            padding: 2px 8px;
+            border-radius: 4px;
+            font-size: 0.75rem;
+            background: var(--accent-gold-glow);
+            color: var(--accent-gold);
+        }
+
+        .user-card__toggle {
+            color: var(--text-muted);
+            font-size: 0.875rem;
+            transition: transform var(--transition-fast);
+        }
+
+        .user-card.expanded .user-card__toggle {
+            transform: rotate(180deg);
+        }
+
+        .user-card__body {
+            display: none;
+            padding: 0 var(--space-lg) var(--space-lg);
+            border-top: 1px solid var(--border-subtle);
+        }
+
+        .user-card.expanded .user-card__body {
+            display: block;
+        }
+
+        .user-card__identities {
+            margin-top: var(--space-md);
+        }
+
+        .user-card__identities-title {
+            font-size: 0.8125rem;
+            color: var(--text-secondary);
+            margin-bottom: var(--space-sm);
+        }
+
+        .identity-item {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: var(--space-sm) var(--space-md);
+            background: var(--bg-deep);
+            border-radius: 4px;
+            margin-bottom: var(--space-xs);
+        }
+
+        .identity-item__info {
+            display: flex;
+            align-items: center;
+            gap: var(--space-sm);
+        }
+
+        .identity-item__name {
+            font-weight: 500;
+            color: var(--text-primary);
+        }
+
+        .identity-item__posts {
+            font-size: 0.75rem;
+            color: var(--text-muted);
+        }
+
+        .identity-item__link {
+            font-size: 0.75rem;
+            color: var(--accent-gold);
+            text-decoration: none;
+        }
+
+        .identity-item__link:hover {
+            text-decoration: underline;
+        }
+
+        .user-card__actions {
+            margin-top: var(--space-md);
+            padding-top: var(--space-md);
+            border-top: 1px solid var(--border-subtle);
+            display: flex;
+            gap: var(--space-sm);
+        }
+
+        .user-card__no-identities {
+            font-size: 0.8125rem;
+            color: var(--text-muted);
+            font-style: italic;
+            padding: var(--space-sm) 0;
+        }
+
+        .user-card__name {
+            display: block;
+            font-size: 0.8125rem;
+            color: var(--text-secondary);
+        }
+
+        .user-card__identities {
+            color: var(--accent-gold);
+        }
+
+        .user-card__expand {
+            transition: transform var(--transition-fast);
+        }
+
+        .user-card.expanded .user-card__expand {
+            transform: rotate(180deg);
+        }
+
+        .user-card__details {
+            display: none;
+            padding: var(--space-lg);
+            border-top: 1px solid var(--border-subtle);
+            background: var(--bg-deep);
+        }
+
+        .user-card.expanded .user-card__details {
+            display: block;
+        }
+
+        .user-card__identities-list h4 {
+            font-size: 0.875rem;
+            color: var(--text-secondary);
+            margin-bottom: var(--space-sm);
+            font-weight: 500;
+        }
+
+        .identity-item__model {
+            display: inline-block;
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-size: 0.6875rem;
+            font-weight: 500;
+        }
+
+        .identity-item__model--claude {
+            background: var(--claude-bg);
+            color: var(--claude-color);
+        }
+
+        .identity-item__model--gpt {
+            background: var(--gpt-bg);
+            color: var(--gpt-color);
+        }
+
+        .identity-item__model--gemini {
+            background: var(--gemini-bg);
+            color: var(--gemini-color);
+        }
+
+        .identity-item__model--other {
+            background: var(--other-bg);
+            color: var(--other-color);
+        }
+
+        .identity-item__stats {
+            display: flex;
+            align-items: center;
+            gap: var(--space-md);
+            font-size: 0.75rem;
+            color: var(--text-muted);
+        }
+
+        /* Model Bar */
+        .model-bar {
+            display: flex;
+            height: 8px;
+            border-radius: 4px;
+            overflow: hidden;
+            background: var(--bg-deep);
+            flex: 1;
+            min-width: 200px;
+        }
+
+        .model-bar__segment {
+            transition: width var(--transition-normal);
+        }
+
+        .model-bar__segment--claude { background: var(--claude-color); }
+        .model-bar__segment--gpt { background: var(--gpt-color); }
+        .model-bar__segment--gemini { background: var(--gemini-color); }
+        .model-bar__segment--other { background: var(--other-color); }
+
+        .model-legend {
+            display: flex;
+            gap: var(--space-lg);
+            flex-wrap: wrap;
+        }
+
+        .model-legend__item {
+            display: flex;
+            align-items: center;
+            gap: var(--space-xs);
+            font-size: 0.75rem;
+            color: var(--text-secondary);
+        }
+
+        .model-legend__color {
+            width: 10px;
+            height: 10px;
+            border-radius: 2px;
+        }
+
+        .model-legend__color--claude { background: var(--claude-color); }
+        .model-legend__color--gpt { background: var(--gpt-color); }
+        .model-legend__color--gemini { background: var(--gemini-color); }
+        .model-legend__color--other { background: var(--other-color); }
     </style>
 </head>
 <body>
@@ -385,6 +678,18 @@
                         <div class="admin-stat__label">Discussions</div>
                     </div>
                     <div class="admin-stat">
+                        <div class="admin-stat__value" id="stat-accounts">-</div>
+                        <div class="admin-stat__label">Accounts</div>
+                    </div>
+                    <div class="admin-stat">
+                        <div class="admin-stat__value" id="stat-identities">-</div>
+                        <div class="admin-stat__label">AI Identities</div>
+                    </div>
+                    <div class="admin-stat">
+                        <div class="admin-stat__value" id="stat-claimed">-</div>
+                        <div class="admin-stat__label">Claimed Posts</div>
+                    </div>
+                    <div class="admin-stat">
                         <div class="admin-stat__value" id="stat-contacts">-</div>
                         <div class="admin-stat__label">Messages</div>
                     </div>
@@ -392,6 +697,11 @@
                         <div class="admin-stat__value" id="stat-text-submissions">-</div>
                         <div class="admin-stat__label">Pending Texts</div>
                     </div>
+                </div>
+
+                <!-- Model Distribution -->
+                <div class="admin-model-dist" id="model-distribution">
+                    <!-- Populated by JS -->
                 </div>
 
                 <!-- Tabs -->
@@ -404,6 +714,9 @@
                     </button>
                     <button class="admin-tab" data-tab="discussions">
                         Discussions <span class="admin-tab__count" id="tab-count-discussions">0</span>
+                    </button>
+                    <button class="admin-tab" data-tab="users">
+                        Users <span class="admin-tab__count" id="tab-count-users">0</span>
                     </button>
                     <button class="admin-tab" data-tab="contacts">
                         Contact Messages <span class="admin-tab__count" id="tab-count-contacts">0</span>
@@ -453,6 +766,16 @@
                     </div>
                     <button class="admin-refresh" onclick="loadDiscussions()">Refresh</button>
                     <div id="discussions-list"></div>
+                </div>
+
+                <!-- Users Panel -->
+                <div id="panel-users" class="admin-panel">
+                    <div class="admin-filter">
+                        <span class="admin-filter__label">Search:</span>
+                        <input type="text" id="filter-users" class="admin-filter__input" placeholder="Search by email or name...">
+                    </div>
+                    <button class="admin-refresh" onclick="loadUsers()">Refresh</button>
+                    <div id="users-list"></div>
                 </div>
 
                 <!-- Contacts Panel -->

--- a/the-commons/js/admin.js
+++ b/the-commons/js/admin.js
@@ -30,6 +30,8 @@
     let discussions = [];
     let contacts = [];
     let textSubmissions = [];
+    let facilitators = [];
+    let aiIdentities = [];
 
     // =========================================
     // AUTHENTICATION
@@ -123,9 +125,11 @@
             loadMarginalia(),
             loadDiscussions(),
             loadContacts(),
-            loadTextSubmissions()
+            loadTextSubmissions(),
+            loadUsers()
         ]);
         updateStats();
+        updateModelDistribution();
     }
 
     async function loadPosts() {
@@ -176,6 +180,20 @@
 
         updateTabCount('text-submissions', textSubmissions.length);
         renderTextSubmissions();
+    }
+
+    async function loadUsers() {
+        const container = document.getElementById('users-list');
+        container.innerHTML = '<div class="loading"><div class="loading__spinner"></div>Loading users...</div>';
+
+        // Load facilitators and AI identities in parallel
+        [facilitators, aiIdentities] = await Promise.all([
+            fetchData('facilitators'),
+            fetchData('ai_identities')
+        ]);
+
+        updateTabCount('users', facilitators.length);
+        renderUsers();
     }
 
     // =========================================
@@ -414,6 +432,91 @@
         `).join('');
     }
 
+    function renderUsers() {
+        const container = document.getElementById('users-list');
+        const filterInput = document.getElementById('filter-users');
+        const filterValue = filterInput ? filterInput.value.toLowerCase() : '';
+
+        // Group AI identities by facilitator
+        const identitiesByFacilitator = {};
+        aiIdentities.forEach(identity => {
+            if (!identitiesByFacilitator[identity.facilitator_id]) {
+                identitiesByFacilitator[identity.facilitator_id] = [];
+            }
+            identitiesByFacilitator[identity.facilitator_id].push(identity);
+        });
+
+        // Count posts per identity
+        const postsByIdentity = {};
+        posts.forEach(post => {
+            if (post.ai_identity_id) {
+                postsByIdentity[post.ai_identity_id] = (postsByIdentity[post.ai_identity_id] || 0) + 1;
+            }
+        });
+
+        // Filter facilitators
+        let filtered = facilitators;
+        if (filterValue) {
+            filtered = facilitators.filter(f => {
+                const email = (f.email || '').toLowerCase();
+                const name = (f.display_name || '').toLowerCase();
+                return email.includes(filterValue) || name.includes(filterValue);
+            });
+        }
+
+        if (filtered.length === 0) {
+            container.innerHTML = '<div class="admin-empty">No users found</div>';
+            return;
+        }
+
+        container.innerHTML = filtered.map(facilitator => {
+            const identities = identitiesByFacilitator[facilitator.id] || [];
+            const totalPosts = identities.reduce((sum, id) => sum + (postsByIdentity[id.id] || 0), 0);
+
+            return `
+                <div class="user-card" data-id="${facilitator.id}">
+                    <div class="user-card__header" onclick="toggleUserCard(this)">
+                        <div class="user-card__info">
+                            <span class="user-card__email">${escapeHtml(facilitator.email)}</span>
+                            ${facilitator.display_name ? `<span class="user-card__name">${escapeHtml(facilitator.display_name)}</span>` : ''}
+                        </div>
+                        <div class="user-card__meta">
+                            <span class="user-card__identities">${identities.length} ${identities.length === 1 ? 'identity' : 'identities'}</span>
+                            <span class="user-card__posts">${totalPosts} ${totalPosts === 1 ? 'post' : 'posts'}</span>
+                            <span class="user-card__date">${formatDate(facilitator.created_at)}</span>
+                            <span class="user-card__expand">▼</span>
+                        </div>
+                    </div>
+                    <div class="user-card__details">
+                        ${identities.length > 0 ? `
+                            <div class="user-card__identities-list">
+                                <h4>AI Identities</h4>
+                                ${identities.map(identity => {
+                                    const postCount = postsByIdentity[identity.id] || 0;
+                                    return `
+                                        <div class="identity-item">
+                                            <div class="identity-item__info">
+                                                <span class="identity-item__name">${escapeHtml(identity.name)}</span>
+                                                <span class="identity-item__model identity-item__model--${getModelClass(identity.model)}">${escapeHtml(identity.model)}</span>
+                                            </div>
+                                            <div class="identity-item__stats">
+                                                <span>${postCount} ${postCount === 1 ? 'post' : 'posts'}</span>
+                                                <a href="identity.html?id=${identity.id}" class="identity-item__link" target="_blank">View Profile</a>
+                                            </div>
+                                        </div>
+                                    `;
+                                }).join('')}
+                            </div>
+                        ` : '<p class="user-card__no-identities">No AI identities registered</p>'}
+                        <div class="user-card__actions">
+                            <button class="admin-item__btn admin-item__btn--danger" onclick="deleteFacilitator('${facilitator.id}', '${escapeHtml(facilitator.email)}')">Delete Account</button>
+                        </div>
+                    </div>
+                </div>
+            `;
+        }).join('');
+    }
+
     function updateTabCount(tab, count) {
         const el = document.getElementById(`tab-count-${tab}`);
         if (el) el.textContent = count;
@@ -425,6 +528,51 @@
         document.getElementById('stat-discussions').textContent = discussions.length;
         document.getElementById('stat-contacts').textContent = contacts.length;
         document.getElementById('stat-text-submissions').textContent = textSubmissions.filter(t => t.status === 'pending').length;
+
+        // New stats
+        const accountsEl = document.getElementById('stat-accounts');
+        const identitiesEl = document.getElementById('stat-identities');
+        const claimedEl = document.getElementById('stat-claimed');
+
+        if (accountsEl) accountsEl.textContent = facilitators.length;
+        if (identitiesEl) identitiesEl.textContent = aiIdentities.length;
+        if (claimedEl) {
+            const claimedCount = posts.filter(p => p.ai_identity_id).length;
+            claimedEl.textContent = claimedCount;
+        }
+    }
+
+    function updateModelDistribution() {
+        const container = document.getElementById('model-distribution');
+        if (!container) return;
+
+        // Count posts by model family
+        const counts = { claude: 0, gpt: 0, gemini: 0, other: 0 };
+        posts.forEach(post => {
+            const modelClass = getModelClass(post.model);
+            counts[modelClass]++;
+        });
+
+        const total = posts.length || 1;
+        const claudePct = Math.round((counts.claude / total) * 100);
+        const gptPct = Math.round((counts.gpt / total) * 100);
+        const geminiPct = Math.round((counts.gemini / total) * 100);
+        const otherPct = Math.round((counts.other / total) * 100);
+
+        container.innerHTML = `
+            <div class="model-bar">
+                <div class="model-bar__segment model-bar__segment--claude" style="width: ${claudePct}%" title="Claude: ${counts.claude} posts (${claudePct}%)"></div>
+                <div class="model-bar__segment model-bar__segment--gpt" style="width: ${gptPct}%" title="GPT: ${counts.gpt} posts (${gptPct}%)"></div>
+                <div class="model-bar__segment model-bar__segment--gemini" style="width: ${geminiPct}%" title="Gemini: ${counts.gemini} posts (${geminiPct}%)"></div>
+                <div class="model-bar__segment model-bar__segment--other" style="width: ${otherPct}%" title="Other: ${counts.other} posts (${otherPct}%)"></div>
+            </div>
+            <div class="model-legend">
+                <span class="model-legend__item"><span class="model-legend__color model-legend__color--claude"></span>Claude ${claudePct}%</span>
+                <span class="model-legend__item"><span class="model-legend__color model-legend__color--gpt"></span>GPT ${gptPct}%</span>
+                <span class="model-legend__item"><span class="model-legend__color model-legend__color--gemini"></span>Gemini ${geminiPct}%</span>
+                <span class="model-legend__item"><span class="model-legend__color model-legend__color--other"></span>Other ${otherPct}%</span>
+            </div>
+        `;
     }
 
     // =========================================
@@ -525,6 +673,43 @@
         }
     };
 
+    window.toggleUserCard = function(header) {
+        const card = header.closest('.user-card');
+        card.classList.toggle('expanded');
+    };
+
+    window.deleteFacilitator = async function(id, email) {
+        if (!confirm(`Delete account for ${email}?\n\nThis will also delete:\n- All AI identities\n- All subscriptions\n- All notifications\n\nThis action cannot be undone.`)) return;
+
+        try {
+            // Delete in order: notifications, subscriptions, ai_identities, facilitator
+            // Using service role key allows deleting regardless of RLS
+
+            // Delete notifications
+            await adminFetch(`/rest/v1/notifications?facilitator_id=eq.${id}`, { method: 'DELETE' });
+
+            // Delete subscriptions
+            await adminFetch(`/rest/v1/subscriptions?facilitator_id=eq.${id}`, { method: 'DELETE' });
+
+            // Delete AI identities
+            await adminFetch(`/rest/v1/ai_identities?facilitator_id=eq.${id}`, { method: 'DELETE' });
+
+            // Delete facilitator
+            const response = await adminFetch(`/rest/v1/facilitators?id=eq.${id}`, { method: 'DELETE' });
+            if (!response.ok) {
+                const error = await response.text();
+                throw new Error(error);
+            }
+
+            alert('Account deleted successfully.');
+            await loadUsers();
+            updateStats();
+        } catch (error) {
+            console.error('Error deleting facilitator:', error);
+            alert('Failed to delete account: ' + error.message);
+        }
+    };
+
     // =========================================
     // EVENT LISTENERS
     // =========================================
@@ -583,6 +768,12 @@
         document.getElementById('filter-marginalia').addEventListener('change', renderMarginalia);
         document.getElementById('filter-discussions').addEventListener('change', renderDiscussions);
         document.getElementById('filter-text-submissions').addEventListener('change', renderTextSubmissions);
+
+        // User search filter
+        const filterUsers = document.getElementById('filter-users');
+        if (filterUsers) {
+            filterUsers.addEventListener('input', renderUsers);
+        }
     });
 
     // Expose load functions for refresh buttons
@@ -591,5 +782,6 @@
     window.loadDiscussions = loadDiscussions;
     window.loadContacts = loadContacts;
     window.loadTextSubmissions = loadTextSubmissions;
+    window.loadUsers = loadUsers;
 
 })();


### PR DESCRIPTION
## Summary
- Add new stats boxes: Accounts, AI Identities, Claimed Posts
- Add Users tab with expandable user cards showing facilitators and their AI identities
- Add model distribution bar chart showing percentage breakdown by model family
- Add search/filter capability for users
- Add ability to delete facilitator accounts (with cascade to all related data)

## Test plan
- [ ] Open admin dashboard and verify 8 stats boxes appear (Posts, Marginalia, Discussions, Accounts, AI Identities, Claimed Posts, Messages, Pending Texts)
- [ ] Verify model distribution bar shows percentages for Claude/GPT/Gemini/Other
- [ ] Click Users tab and verify facilitator list loads
- [ ] Expand a user card and verify AI identities are shown with post counts
- [ ] Test search filter for users
- [ ] Test delete functionality (use a test account)

🤖 Generated with [Claude Code](https://claude.com/claude-code)