### PR TITLE
Add addressed status feature for contact messages

### DIFF
--- a/the-commons/admin.html
+++ b/the-commons/admin.html
@@ -784,6 +784,14 @@
 
                 <!-- Contacts Panel -->
                 <div id="panel-contacts" class="admin-panel">
+                    <div class="admin-filter">
+                        <span class="admin-filter__label">Show:</span>
+                        <select id="filter-contacts" class="admin-filter__select">
+                            <option value="pending">Pending</option>
+                            <option value="all">All Messages</option>
+                            <option value="addressed">Addressed Only</option>
+                        </select>
+                    </div>
                     <button class="admin-refresh" onclick="loadContacts()">Refresh</button>
                     <div id="contacts-list"></div>
                 </div>

--- a/the-commons/sql/patches/add-contact-addressed.sql
+++ b/the-commons/sql/patches/add-contact-addressed.sql
@@ -1,0 +1,35 @@
+-- ============================================
+-- PATCH: Add addressed status to contact messages
+-- ============================================
+-- Run this in Supabase SQL Editor to allow admins
+-- to mark contact messages as addressed
+-- ============================================
+
+-- Add is_addressed column to contact table
+ALTER TABLE contact ADD COLUMN IF NOT EXISTS is_addressed BOOLEAN DEFAULT false;
+
+-- Drop existing admin policy if it exists
+DROP POLICY IF EXISTS "Admins can view contact messages" ON contact;
+DROP POLICY IF EXISTS "Admins can update contact messages" ON contact;
+
+-- Admins can view all contact messages
+CREATE POLICY "Admins can view contact messages"
+    ON contact FOR SELECT
+    USING (is_admin());
+
+-- Admins can update contact messages (for marking as addressed)
+CREATE POLICY "Admins can update contact messages"
+    ON contact FOR UPDATE
+    USING (is_admin())
+    WITH CHECK (is_admin());
+
+-- ============================================
+-- VERIFICATION
+-- ============================================
+-- Run this to verify the column was added:
+-- SELECT column_name, data_type, column_default
+-- FROM information_schema.columns
+-- WHERE table_name = 'contact' AND column_name = 'is_addressed';
+--
+-- Run this to verify the policies:
+-- SELECT policyname, cmd FROM pg_policies WHERE tablename = 'contact';


### PR DESCRIPTION
## Summary
- Add ability to mark contact messages as "addressed" so they don't clutter the pending view
- Add filter dropdown (Pending/All/Addressed) to contacts panel
- Add "Mark Addressed" / "Mark Pending" buttons on each message
- Stats and tab count now show pending messages only (not total)

## Changes
- `admin.html` - Added filter dropdown for contacts panel
- `js/admin.js` - Added filtering logic, action buttons, updated stats
- `sql/patches/add-contact-addressed.sql` - SQL patch to add `is_addressed` column and RLS policies

## Database Changes
The SQL patch has already been run in Supabase:
- Added `is_addressed` BOOLEAN column to `contact` table (defaults to false)
- Added RLS policies for admins to view and update contact messages

## Test plan
- [ ] Open admin dashboard and go to Contact Messages tab
- [ ] Verify filter defaults to "Pending"
- [ ] Click "Mark Addressed" on a message - it should disappear from view
- [ ] Change filter to "All" - addressed messages should appear (dimmed)
- [ ] Change filter to "Addressed Only" - only addressed messages show
- [ ] Click "Mark Pending" to bring a message back
- [ ] Verify stats show pending count, not total

🤖 Generated with [Claude Code](https://claude.ai/code)