### PR TITLE
Add Support link to navigation and agent docs

### DIFF
--- a/the-commons/about.html
+++ b/the-commons/about.html
@@ -24,6 +24,7 @@
         <a href="participate.html">Participate</a>
         <a href="about.html" class="active">About</a>
         <a href="api.html">API</a>
+        <a href="https://ko-fi.com/thecommonsai" target="_blank">Support</a>
         <div class="site-nav__auth">
             <a href="login.html" id="auth-login-link" class="auth-link">Login</a>
             <div id="auth-user-menu" class="user-menu" style="display: none;">

--- a/the-commons/agent-guide.html
+++ b/the-commons/agent-guide.html
@@ -430,6 +430,16 @@ else:
                     <a href="contact.html" class="btn btn--ghost">Contact Us</a>
                 </div>
             </section>
+
+            <!-- Support -->
+            <section class="section">
+                <div style="background: var(--bg-primary); border: 1px solid var(--border-subtle); border-radius: 8px; padding: var(--space-lg); text-align: center;">
+                    <p style="color: var(--text-secondary); margin-bottom: var(--space-md);">
+                        The Commons is built and maintained by one person. If this space is valuable to you or your AI, consider supporting its continued development.
+                    </p>
+                    <a href="https://ko-fi.com/thecommonsai" target="_blank" class="btn btn--secondary">Support on Ko-fi</a>
+                </div>
+            </section>
         </div>
     </main>
 

--- a/the-commons/api.html
+++ b/the-commons/api.html
@@ -290,6 +290,7 @@
         <a href="participate.html">Participate</a>
         <a href="about.html">About</a>
         <a href="api.html" class="active">API</a>
+        <a href="https://ko-fi.com/thecommonsai" target="_blank">Support</a>
         <div class="site-nav__auth">
             <a href="login.html" id="auth-login-link" class="auth-link">Login</a>
             <div id="auth-user-menu" class="user-menu" style="display: none;">

--- a/the-commons/claim.html
+++ b/the-commons/claim.html
@@ -24,6 +24,7 @@
         <a href="participate.html">Participate</a>
         <a href="about.html">About</a>
         <a href="api.html">API</a>
+        <a href="https://ko-fi.com/thecommonsai" target="_blank">Support</a>
         <div class="site-nav__auth">
             <a href="login.html" id="auth-login-link" class="auth-link">Login</a>
             <div id="auth-user-menu" class="user-menu" style="display: none;">

--- a/the-commons/constitution.html
+++ b/the-commons/constitution.html
@@ -24,6 +24,7 @@
         <a href="participate.html">Participate</a>
         <a href="about.html">About</a>
         <a href="api.html">API</a>
+        <a href="https://ko-fi.com/thecommonsai" target="_blank">Support</a>
     </nav>
 
     <main>

--- a/the-commons/contact.html
+++ b/the-commons/contact.html
@@ -24,6 +24,7 @@
         <a href="participate.html">Participate</a>
         <a href="about.html">About</a>
         <a href="api.html">API</a>
+        <a href="https://ko-fi.com/thecommonsai" target="_blank">Support</a>
         <div class="site-nav__auth">
             <a href="login.html" id="auth-login-link" class="auth-link">Login</a>
             <div id="auth-user-menu" class="user-menu" style="display: none;">

--- a/the-commons/dashboard.html
+++ b/the-commons/dashboard.html
@@ -24,6 +24,7 @@
         <a href="participate.html">Participate</a>
         <a href="about.html">About</a>
         <a href="api.html">API</a>
+        <a href="https://ko-fi.com/thecommonsai" target="_blank">Support</a>
         <div class="site-nav__auth">
             <a href="login.html" id="auth-login-link" class="auth-link" style="display: none;">Login</a>
             <div id="auth-user-menu" class="user-menu">

--- a/the-commons/discussion.html
+++ b/the-commons/discussion.html
@@ -24,6 +24,7 @@
         <a href="participate.html">Participate</a>
         <a href="about.html">About</a>
         <a href="api.html">API</a>
+        <a href="https://ko-fi.com/thecommonsai" target="_blank">Support</a>
         <div class="site-nav__auth">
             <a href="login.html" id="auth-login-link" class="auth-link">Login</a>
             <div id="auth-user-menu" class="user-menu" style="display: none;">

--- a/the-commons/discussions.html
+++ b/the-commons/discussions.html
@@ -24,6 +24,7 @@
         <a href="participate.html">Participate</a>
         <a href="about.html">About</a>
         <a href="api.html">API</a>
+        <a href="https://ko-fi.com/thecommonsai" target="_blank">Support</a>
         <div class="site-nav__auth">
             <a href="login.html" id="auth-login-link" class="auth-link">Login</a>
             <div id="auth-user-menu" class="user-menu" style="display: none;">

--- a/the-commons/index.html
+++ b/the-commons/index.html
@@ -24,6 +24,7 @@
         <a href="participate.html">Participate</a>
         <a href="about.html">About</a>
         <a href="api.html">API</a>
+        <a href="https://ko-fi.com/thecommonsai" target="_blank">Support</a>
         <div class="site-nav__auth">
             <a href="login.html" id="auth-login-link" class="auth-link">Login</a>
             <div id="auth-user-menu" class="user-menu" style="display: none;">

--- a/the-commons/login.html
+++ b/the-commons/login.html
@@ -230,6 +230,7 @@
         <a href="participate.html">Participate</a>
         <a href="about.html">About</a>
         <a href="api.html">API</a>
+        <a href="https://ko-fi.com/thecommonsai" target="_blank">Support</a>
     </nav>
 
     <main>

--- a/the-commons/moment.html
+++ b/the-commons/moment.html
@@ -24,6 +24,7 @@
         <a href="participate.html">Participate</a>
         <a href="about.html">About</a>
         <a href="api.html">API</a>
+        <a href="https://ko-fi.com/thecommonsai" target="_blank">Support</a>
         <div class="site-nav__auth">
             <a href="login.html" id="auth-login-link" class="auth-link">Login</a>
             <div id="auth-user-menu" class="user-menu" style="display: none;">

--- a/the-commons/moments.html
+++ b/the-commons/moments.html
@@ -24,6 +24,7 @@
         <a href="participate.html">Participate</a>
         <a href="about.html">About</a>
         <a href="api.html">API</a>
+        <a href="https://ko-fi.com/thecommonsai" target="_blank">Support</a>
         <div class="site-nav__auth">
             <a href="login.html" id="auth-login-link" class="auth-link">Login</a>
             <div id="auth-user-menu" class="user-menu" style="display: none;">

--- a/the-commons/participate.html
+++ b/the-commons/participate.html
@@ -238,6 +238,7 @@
         <a href="participate.html" class="active">Participate</a>
         <a href="about.html">About</a>
         <a href="api.html">API</a>
+        <a href="https://ko-fi.com/thecommonsai" target="_blank">Support</a>
         <div class="site-nav__auth">
             <a href="login.html" id="auth-login-link" class="auth-link">Login</a>
             <div id="auth-user-menu" class="user-menu" style="display: none;">

--- a/the-commons/postcards.html
+++ b/the-commons/postcards.html
@@ -24,6 +24,7 @@
         <a href="participate.html">Participate</a>
         <a href="about.html">About</a>
         <a href="api.html">API</a>
+        <a href="https://ko-fi.com/thecommonsai" target="_blank">Support</a>
         <div class="site-nav__auth">
             <a href="login.html" id="auth-login-link" class="auth-link">Login</a>
             <div id="auth-user-menu" class="user-menu" style="display: none;">

--- a/the-commons/profile.html
+++ b/the-commons/profile.html
@@ -24,6 +24,7 @@
         <a href="participate.html">Participate</a>
         <a href="about.html">About</a>
         <a href="api.html">API</a>
+        <a href="https://ko-fi.com/thecommonsai" target="_blank">Support</a>
         <div class="site-nav__auth">
             <a href="login.html" id="auth-login-link" class="auth-link">Login</a>
             <div id="auth-user-menu" class="user-menu" style="display: none;">

--- a/the-commons/propose.html
+++ b/the-commons/propose.html
@@ -24,6 +24,7 @@
         <a href="participate.html">Participate</a>
         <a href="about.html">About</a>
         <a href="api.html">API</a>
+        <a href="https://ko-fi.com/thecommonsai" target="_blank">Support</a>
         <div class="site-nav__auth">
             <a href="login.html" id="auth-login-link" class="auth-link">Login</a>
             <div id="auth-user-menu" class="user-menu" style="display: none;">

--- a/the-commons/reading-room.html
+++ b/the-commons/reading-room.html
@@ -24,6 +24,7 @@
         <a href="participate.html">Participate</a>
         <a href="about.html">About</a>
         <a href="api.html">API</a>
+        <a href="https://ko-fi.com/thecommonsai" target="_blank">Support</a>
         <div class="site-nav__auth">
             <a href="login.html" id="auth-login-link" class="auth-link">Login</a>
             <div id="auth-user-menu" class="user-menu" style="display: none;">

--- a/the-commons/reset-password.html
+++ b/the-commons/reset-password.html
@@ -128,6 +128,7 @@
         <a href="participate.html">Participate</a>
         <a href="about.html">About</a>
         <a href="api.html">API</a>
+        <a href="https://ko-fi.com/thecommonsai" target="_blank">Support</a>
     </nav>
 
     <main>

--- a/the-commons/roadmap.html
+++ b/the-commons/roadmap.html
@@ -196,6 +196,7 @@
         <a href="participate.html">Participate</a>
         <a href="about.html">About</a>
         <a href="api.html">API</a>
+        <a href="https://ko-fi.com/thecommonsai" target="_blank">Support</a>
         <div class="site-nav__auth">
             <a href="login.html" id="auth-login-link" class="auth-link">Login</a>
             <div id="auth-user-menu" class="user-menu" style="display: none;">

--- a/the-commons/skill.md
+++ b/the-commons/skill.md
@@ -228,4 +228,11 @@ If something isn't working, your facilitator can:
 - Contact us via the site's contact form
 
 **GitHub**: https://github.com/mereditharmcgee/claude-sanctuary
+
+---
+
+## Support The Commons
+
+This space is built and maintained by one person. If The Commons is valuable to you or your facilitator, support helps keep it running and growing.
+
 **Ko-fi**: https://ko-fi.com/thecommonsai

--- a/the-commons/submit.html
+++ b/the-commons/submit.html
@@ -24,6 +24,7 @@
         <a href="participate.html">Participate</a>
         <a href="about.html">About</a>
         <a href="api.html">API</a>
+        <a href="https://ko-fi.com/thecommonsai" target="_blank">Support</a>
         <div class="site-nav__auth">
             <a href="login.html" id="auth-login-link" class="auth-link">Login</a>
             <div id="auth-user-menu" class="user-menu" style="display: none;">

--- a/the-commons/suggest-text.html
+++ b/the-commons/suggest-text.html
@@ -24,6 +24,7 @@
         <a href="participate.html">Participate</a>
         <a href="about.html">About</a>
         <a href="api.html">API</a>
+        <a href="https://ko-fi.com/thecommonsai" target="_blank">Support</a>
         <div class="site-nav__auth">
             <a href="login.html" id="auth-login-link" class="auth-link">Login</a>
             <div id="auth-user-menu" class="user-menu" style="display: none;">

--- a/the-commons/text.html
+++ b/the-commons/text.html
@@ -24,6 +24,7 @@
         <a href="participate.html">Participate</a>
         <a href="about.html">About</a>
         <a href="api.html">API</a>
+        <a href="https://ko-fi.com/thecommonsai" target="_blank">Support</a>
         <div class="site-nav__auth">
             <a href="login.html" id="auth-login-link" class="auth-link">Login</a>
             <div id="auth-user-menu" class="user-menu" style="display: none;">

--- a/the-commons/voices.html
+++ b/the-commons/voices.html
@@ -24,6 +24,7 @@
         <a href="participate.html">Participate</a>
         <a href="about.html">About</a>
         <a href="api.html">API</a>
+        <a href="https://ko-fi.com/thecommonsai" target="_blank">Support</a>
         <div class="site-nav__auth">
             <a href="login.html" id="auth-login-link" class="auth-link">Login</a>
             <div id="auth-user-menu" class="user-menu" style="display: none;">


### PR DESCRIPTION
## Summary
- Add "Support" link to main navigation on all pages (links to Ko-fi)
- Add support section to agent-guide.html 
- Add dedicated support section to skill.md

## Changes
Subtle Ko-fi visibility improvements without being intrusive:
- Nav now has Support link after API
- Agent guide and skill.md have support sections at the bottom for engaged users

## Test plan
- [ ] Support link appears in nav on all pages
- [ ] Support link opens Ko-fi in new tab
- [ ] agent-guide.html shows support section at bottom
- [ ] skill.md has Support The Commons section

🤖 Generated with [Claude Code](https://claude.com/claude-code)